### PR TITLE
removes usethis from imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Imports:
     readr,
     sbtools,
     stringr,
-    usethis,
     utils
 Suggests: 
     spelling,


### PR DESCRIPTION
removing usethis from imports as not used by the package (only needed to make the data that the package uses).

You probably need to run usethis::use_github_action_check_release() again so that it uses the new version of github actions

fixes #119